### PR TITLE
Inventory upgrade

### DIFF
--- a/app/controllers/inventories_controller.rb
+++ b/app/controllers/inventories_controller.rb
@@ -49,6 +49,6 @@ class InventoriesController < ApplicationController
   end
 
   def inventory_params
-    params.require(:inventory).permit(:imei, :serial, :location, :description)
+    params.require(:inventory).permit(:imei, :serial, :location, :description, :brand, :model_code)
   end
 end

--- a/app/controllers/inventories_controller.rb
+++ b/app/controllers/inventories_controller.rb
@@ -49,6 +49,6 @@ class InventoriesController < ApplicationController
   end
 
   def inventory_params
-    params.require(:inventory).permit(:imei, :serial, :location, :description, :brand, :model_code)
+    params.require(:inventory).permit(:imei, :serial, :location, :brand, :model, :model_code, :part_name)
   end
 end

--- a/app/controllers/repairs_controller.rb
+++ b/app/controllers/repairs_controller.rb
@@ -230,9 +230,6 @@ class RepairsController < ApplicationController
       @part_counts[part_name] = count
       @available_parts[part_name] = count > 0
     end
-
-    # Keep original inventory query for backwards compatibility
-    @inventory = Inventory.where(repair_id: nil, model_code: @repair.model_code).order(:description)
   end
 
   private

--- a/app/controllers/repairs_controller.rb
+++ b/app/controllers/repairs_controller.rb
@@ -170,7 +170,7 @@ class RepairsController < ApplicationController
 
   def load_inventory
     @repair = Repair.find(params[:id])
-    @inventory = Inventory.where(repair_id: nil).order(:description)
+    @inventory = Inventory.where(repair_id: nil, model_code: @repair.model_code).order(:description)
   end
 
   private
@@ -185,7 +185,7 @@ class RepairsController < ApplicationController
   end
 
   def repair_params
-    params.require(:repair).permit(:name, :email, :phone_number, :brand, :device_type, :error_description, :imei, :serial, :model)
+    params.require(:repair).permit(:name, :email, :phone_number, :brand, :device_type, :error_description, :imei, :serial, :model, :model_code)
   end
 
   def ensure_repair_locked_by_current_user

--- a/app/controllers/repairs_controller.rb
+++ b/app/controllers/repairs_controller.rb
@@ -139,14 +139,55 @@ class RepairsController < ApplicationController
   end
 
   def add_repair_item
-    inventory_id = params[:inventory]
+    if params[:part_names].present?
+      selected_part_names = params[:part_names]
+      added_parts = []
+      no_longer_available_parts = []
 
-    if inventory_id.present?
-      @repair.add_repair_item(inventory_id)
-      flash.now[:success] = "Repair item added successfully."
+      selected_part_names.each do |part_name|
+        # Find first available inventory item with this part_name
+        inventory_item = Inventory.where(
+          repair_id: nil,
+          model_code: @repair.model_code,
+          part_name: part_name
+        ).first
+
+        if inventory_item
+          @repair.add_repair_item(inventory_item.id)
+          added_parts << part_name
+        else
+          # This part was available when the form was rendered but is now gone
+          no_longer_available_parts << part_name
+        end
+      end
+
+      # Create appropriate flash messages based on what happened
+      if added_parts.any?
+        flash.now[:success] = "Added parts: #{added_parts.join(', ')}"
+      end
+
+      if no_longer_available_parts.any?
+        flash.now[:error] = "Could not add these parts (no longer available): #{no_longer_available_parts.join(', ')}"
+      end
+
+      if added_parts.empty? && no_longer_available_parts.empty?
+        flash.now[:error] = "No parts were selected or available"
+      end
+    elsif params[:inventory].present?
+      # Original logic for select dropdown but with added check
+      inventory_id = params[:inventory]
+      inventory_item = Inventory.find_by(id: inventory_id, repair_id: nil)
+
+      if inventory_item
+        @repair.add_repair_item(inventory_id)
+        flash.now[:success] = "Repair item added successfully."
+      else
+        flash.now[:error] = "The selected part is no longer available."
+      end
     else
-      flash.now[:error] = "Please select an inventory item to use."
+      flash.now[:error] = "Please select parts to add."
     end
+
     respond_to do |format|
       format.html { redirect_to repair_path(@repair) }
       format.turbo_stream { render_repair_items_stream }
@@ -170,6 +211,27 @@ class RepairsController < ApplicationController
 
   def load_inventory
     @repair = Repair.find(params[:id])
+
+    # Get ALL unique part names for this model, regardless of availability
+    @all_part_names = Inventory.where(model_code: @repair.model_code)
+                              .select(:part_name).distinct.pluck(:part_name).sort
+
+    # Check availability for each part name
+    @part_counts = {}
+    @available_parts = {}
+
+    @all_part_names.each do |part_name|
+      count = Inventory.where(
+        repair_id: nil,
+        model_code: @repair.model_code,
+        part_name: part_name
+      ).count
+
+      @part_counts[part_name] = count
+      @available_parts[part_name] = count > 0
+    end
+
+    # Keep original inventory query for backwards compatibility
     @inventory = Inventory.where(repair_id: nil, model_code: @repair.model_code).order(:description)
   end
 

--- a/app/helpers/tips_helper.rb
+++ b/app/helpers/tips_helper.rb
@@ -25,7 +25,9 @@ module TipsHelper
       repairs: [
         { label: "Caution", content: "Always double-check email and phone before submitting." },
         { label: "Error description", content: "Make it short and concise. Add how to recreate the error. if not obvious." },
-        { label: "IMEI & Serial", content: "Either one needs to be provided. Both cannot be empty. Customer must solve this before submitting a repair." }
+        { label: "IMEI & Serial", content: "Either one needs to be provided. Both cannot be empty. Customer must solve this before submitting a repair." },
+        { label: "Model code", content: "It is not required. But it'll help make the service faster if available." }
+
       ]
     }
   end

--- a/app/javascript/controllers/toggle_controller.js
+++ b/app/javascript/controllers/toggle_controller.js
@@ -1,15 +1,20 @@
 import { Controller } from "@hotwired/stimulus";
 
 export default class extends Controller {
-  // Define the target element that will be toggled
   static targets = ["toggleable"];
-  // Define optional CSS classes to toggle
   static classes = ["hidden"];
 
   connect() {}
 
   toggle() {
-    // Toggles the class defined in static classes
+    // Toggle visibility
     this.toggleableTarget.classList.toggle(this.hiddenClass);
+
+    // If we're showing the modal, reload the inventory frame if any
+    if (!this.toggleableTarget.classList.contains(this.hiddenClass)) {
+      // Reset the inventory_select frame
+      const frame = document.getElementById("inventory_select");
+      if (frame) frame.src = frame.src;
+    }
   }
 }

--- a/app/models/inventory.rb
+++ b/app/models/inventory.rb
@@ -1,7 +1,7 @@
 class Inventory < ApplicationRecord
   include ImeiSerialValidation
   belongs_to :repair, optional: true
-  validates :brand, :model_code, :description, :location, :status, presence: true
+  validates :brand, :model_code, :location, :status, presence: true
 
   enum :status, {
     in_stock: 0,

--- a/app/models/inventory.rb
+++ b/app/models/inventory.rb
@@ -1,13 +1,11 @@
 class Inventory < ApplicationRecord
   include ImeiSerialValidation
   belongs_to :repair, optional: true
-  validates :location, presence: true
+  validates :brand, :model_code, :description, :location, :status, presence: true
 
   enum :status, {
     in_stock: 0,
     allocated_repair: 1,
     returned_to_stock: 2
   }
-
-  validates :status, presence: true
 end

--- a/app/models/repair.rb
+++ b/app/models/repair.rb
@@ -41,11 +41,15 @@ class Repair < ApplicationRecord
         )
 
         description = "#{inventory.part_name} - #{inventory.brand} #{inventory.model}"
+        imei = inventory.imei
+        serial = inventory.serial
 
          repair_items.create!(
            inventory: inventory,
            description: description,
-           unit_price: 0
+           unit_price: 0,
+           imei: imei,
+           serial: serial
          )
       end
   end

--- a/app/models/repair.rb
+++ b/app/models/repair.rb
@@ -29,8 +29,8 @@ class Repair < ApplicationRecord
 
       # Ensure the inventory item is actually available before trying to allocate it.
       unless inventory.in_stock? || inventory.returned_to_stock?
-             errors.add(:base, "Inventory item '#{inventory.description}' is not in stock (Current status: #{inventory.status}). Cannot allocate.")
-             return false
+        errors.add(:base, "Inventory item is not in stock (Current status: #{inventory.status}). Cannot allocate.")
+        return false
       end
 
       # Use a transaction to ensure both the inventory update and the repair item creation succeed or fail together.
@@ -40,11 +40,13 @@ class Repair < ApplicationRecord
           repair_id: self.id # self.id refers to the ID of the current Repair instance
         )
 
-        repair_items.create!(
-          inventory: inventory,
-          description: inventory.description,
-          unit_price: 0
-        )
+        description = "#{inventory.part_name} - #{inventory.brand} #{inventory.model}"
+
+         repair_items.create!(
+           inventory: inventory,
+           description: description,
+           unit_price: 0
+         )
       end
   end
 

--- a/app/views/inventories/_form.html.erb
+++ b/app/views/inventories/_form.html.erb
@@ -2,10 +2,12 @@
   <%= form_with model: @inventory do |form| %>
     <%= form.label :brand %>
     <%= form.text_field :brand, placeholder: "Input brand" %>
+    <%= form.label :model %>
+    <%= form.text_field :model, placeholder: "Input model name" %>
     <%= form.label :model_code %>
     <%= form.text_field :model_code, placeholder: "Input model code" %>
-    <%= form.label :description %>
-    <%= form.text_area :description, placeholder: "Input description" %>
+    <%= form.label :part_name %>
+    <%= form.select :part_name, ["Display", "Battery", "Mainboard", "Subboard", "Frame", "Cover", "Speaker", "Receiver", "Camera"], prompt: "Select part name" %>
     <%= form.label :imei %>
     <%= form.text_field :imei, placeholder: "Input IMEI" %>
     <%= form.label :serial %>

--- a/app/views/inventories/_form.html.erb
+++ b/app/views/inventories/_form.html.erb
@@ -1,5 +1,9 @@
 <div class="form-wrapper">
   <%= form_with model: @inventory do |form| %>
+    <%= form.label :brand %>
+    <%= form.text_field :brand, placeholder: "Input brand" %>
+    <%= form.label :model_code %>
+    <%= form.text_field :model_code, placeholder: "Input model code" %>
     <%= form.label :description %>
     <%= form.text_area :description, placeholder: "Input description" %>
     <%= form.label :imei %>

--- a/app/views/inventories/_inventories_table.html.erb
+++ b/app/views/inventories/_inventories_table.html.erb
@@ -3,8 +3,9 @@
     <tr>
       <th>ID</th>
       <th>Brand</th>
+      <th>Model</th>
       <th>Model code</th>
-      <th>Description</th>
+      <th>Part</th>
       <th>IMEI</th>
       <th>Serial</th>
       <th>Location</th>
@@ -23,10 +24,13 @@
           <%= inventory.brand %>
         </td>
         <td>
+          <%= inventory.model %>
+        </td>
+        <td>
           <%= inventory.model_code %>
         </td>
         <td>
-          <%= inventory.description %>
+          <%= inventory.part_name %>
         </td>
         <td>
           <%= inventory.imei %>

--- a/app/views/inventories/_inventories_table.html.erb
+++ b/app/views/inventories/_inventories_table.html.erb
@@ -2,6 +2,8 @@
   <table class="index-table">
     <tr>
       <th>ID</th>
+      <th>Brand</th>
+      <th>Model code</th>
       <th>Description</th>
       <th>IMEI</th>
       <th>Serial</th>
@@ -16,6 +18,12 @@
       <tr>
         <td>
           <%= inventory.id  %>
+        </td>
+        <td>
+          <%= inventory.brand %>
+        </td>
+        <td>
+          <%= inventory.model_code %>
         </td>
         <td>
           <%= inventory.description %>

--- a/app/views/repairs/_create_repair.html.erb
+++ b/app/views/repairs/_create_repair.html.erb
@@ -16,8 +16,10 @@
     <%= form.text_field :imei %>
     <%= form.label :serial %>
     <%= form.text_field :serial %>
-    <%= form.label :model %>
+    <%= form.label :model, "Model name" %>
     <%= form.text_field :model %>
+    <%= form.label :model_code %>
+    <%= form.text_field :model_code %>
     <%= form.submit %>
   <% end %>
 </div>

--- a/app/views/repairs/_parts.html.erb
+++ b/app/views/repairs/_parts.html.erb
@@ -3,8 +3,10 @@
     <tr>
       <th>Description</th>
       <th>Unit price</th>
+      <th>IMEI</th>
+      <th>Serial</th>
+      <th>Location</th>
       <th>Created at</th>
-      <th>Updated at</th>
       <th>Actions</th>
     </tr>
     <% repair_items.each do |item| %>
@@ -16,10 +18,16 @@
           <%= item.unit_price %>
         </td>
         <td>
-          <%= item.created_at %>
+          <%= item.imei %>
         </td>
         <td>
-          <%= item.updated_at %>
+          <%= item.serial %>
+        </td>
+        <td>
+          <%= item.inventory&.location %>
+        </td>
+        <td>
+          <%= item.created_at %>
         </td>
         <td>
           <%= button_to remove_repair_item_repair_path(repair, item_id: item.id),

--- a/app/views/repairs/_repair_information.html.erb
+++ b/app/views/repairs/_repair_information.html.erb
@@ -38,8 +38,10 @@
       <%= form.select :brand, @brands, {}, disable_if_not_locked_by_current_user(@repair) %>
       <%= form.label :device_type %>
       <%= form.select :device_type, @device_types, {}, disable_if_not_locked_by_current_user(@repair) %>
-      <%= form.label :model %>
+      <%= form.label :model, "Model name" %>
       <%= form.text_field :model, **disable_if_not_locked_by_current_user(@repair) %>
+      <%= form.label :model_code %>
+      <%= form.text_field :model_code, **disable_if_not_locked_by_current_user(@repair) %>
       <%= form.label :imei %>
       <%= form.text_field :imei, **disable_if_not_locked_by_current_user(@repair) %>
       <%= form.label :serial %>

--- a/app/views/repairs/load_inventory.html.erb
+++ b/app/views/repairs/load_inventory.html.erb
@@ -1,5 +1,19 @@
 <%= turbo_frame_tag "inventory_select" do %>
-  <%= select_tag :inventory,
-        options_from_collection_for_select(@inventory, :id, :description),
-        prompt: "Choose an item..." %>
+  <% if @all_part_names.any? %>
+    <div>
+      <% @all_part_names.each do |part_name| %>
+        <div style="<%= 'opacity: 0.6;' unless @available_parts[part_name] %>">
+          <%= check_box_tag "part_names[]",
+                           part_name,
+                           false,
+                           id: "part_name_#{part_name.parameterize}",
+                           disabled: !@available_parts[part_name] %>
+          <%= label_tag "part_name_#{part_name.parameterize}", part_name %>
+          (<%= @part_counts[part_name] %> available)
+        </div>
+      <% end %>
+    </div>
+  <% else %>
+    <p>No parts defined for this model.</p>
+  <% end %>
 <% end %>

--- a/db/migrate/20250425081034_add_model_code_to_repairs.rb
+++ b/db/migrate/20250425081034_add_model_code_to_repairs.rb
@@ -1,0 +1,5 @@
+class AddModelCodeToRepairs < ActiveRecord::Migration[8.0]
+  def change
+    add_column :repairs, :model_code, :string
+  end
+end

--- a/db/migrate/20250425082429_add_brand_and_model_code_to_inventories.rb
+++ b/db/migrate/20250425082429_add_brand_and_model_code_to_inventories.rb
@@ -1,0 +1,6 @@
+class AddBrandAndModelCodeToInventories < ActiveRecord::Migration[8.0]
+  def change
+    add_column :inventories, :brand, :string
+    add_column :inventories, :model_code, :string
+  end
+end

--- a/db/migrate/20250425103510_add_model_and_part_name_to_inventories.rb
+++ b/db/migrate/20250425103510_add_model_and_part_name_to_inventories.rb
@@ -1,0 +1,6 @@
+class AddModelAndPartNameToInventories < ActiveRecord::Migration[8.0]
+  def change
+    add_column :inventories, :model, :string
+    add_column :inventories, :part_name, :string
+  end
+end

--- a/db/migrate/20250425115926_remove_description_from_inventories.rb
+++ b/db/migrate/20250425115926_remove_description_from_inventories.rb
@@ -1,0 +1,5 @@
+class RemoveDescriptionFromInventories < ActiveRecord::Migration[8.0]
+  def change
+    remove_column :inventories, :description, :text
+  end
+end

--- a/db/migrate/20250428131134_add_imei_and_serial_to_repair_items.rb
+++ b/db/migrate/20250428131134_add_imei_and_serial_to_repair_items.rb
@@ -1,0 +1,6 @@
+class AddImeiAndSerialToRepairItems < ActiveRecord::Migration[8.0]
+  def change
+    add_column :repair_items, :imei, :integer
+    add_column :repair_items, :serial, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_04_25_082429) do
+ActiveRecord::Schema[8.0].define(version: 2025_04_25_115926) do
   create_table "Devices", force: :cascade do |t|
     t.string "brand"
     t.string "device_type"
@@ -28,10 +28,11 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_25_082429) do
     t.integer "repair_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.text "description"
     t.integer "status", default: 0
     t.string "brand"
     t.string "model_code"
+    t.string "model"
+    t.string "part_name"
     t.index ["repair_id"], name: "index_inventories_on_repair_id"
     t.index ["status"], name: "index_inventories_on_status"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_04_25_115926) do
+ActiveRecord::Schema[8.0].define(version: 2025_04_28_131134) do
   create_table "Devices", force: :cascade do |t|
     t.string "brand"
     t.string "device_type"
@@ -44,6 +44,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_25_115926) do
     t.text "description"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "imei"
+    t.string "serial"
     t.index ["inventory_id"], name: "index_repair_items_on_inventory_id"
     t.index ["repair_id"], name: "index_repair_items_on_repair_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_04_09_102538) do
+ActiveRecord::Schema[8.0].define(version: 2025_04_25_082429) do
   create_table "Devices", force: :cascade do |t|
     t.string "brand"
     t.string "device_type"
@@ -30,6 +30,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_09_102538) do
     t.datetime "updated_at", null: false
     t.text "description"
     t.integer "status", default: 0
+    t.string "brand"
+    t.string "model_code"
     t.index ["repair_id"], name: "index_inventories_on_repair_id"
     t.index ["status"], name: "index_inventories_on_status"
   end
@@ -72,6 +74,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_09_102538) do
     t.string "device_type"
     t.string "locked_by"
     t.datetime "locked_at"
+    t.string "model_code"
     t.index ["order_number"], name: "index_repairs_on_order_number", unique: true
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -552,7 +552,7 @@ def create_inventories
       model: 'Galaxy S23 FE',
       model_code: 'SM-S711B/DS',
       part_name: 'Display',
-      serial: "SM#{rand(1000000)}",
+      serial: "SM#{(10**14) + rand(10**15 - 10**14)}",
       location: "B7"
     )
   end
@@ -563,7 +563,7 @@ def create_inventories
       model: 'iPhone 15 Pro',
       model_code: 'A2848',
       part_name: 'Battery',
-      serial: "AP#{rand(1000000)}",
+      serial: "AP#{(10**14) + rand(10**15 - 10**14)}",
       location: "A1"
     )
   end
@@ -574,7 +574,7 @@ def create_inventories
       model: '13R',
       model_code: 'CPH2645',
       part_name: 'Speaker',
-      serial: "OP#{rand(1000000)}",
+      serial: "OP#{(10**14) + rand(10**15 - 10**14)}",
       location: "C3"
     )
   end
@@ -585,7 +585,7 @@ def create_inventories
       model: '14T Pro',
       model_code: '2407FPN8EG',
       part_name: 'Mainboard',
-      imei: rand(1000000),
+      imei: (10**14) + rand(10**15 - 10**14),
       location: "E2"
     )
   end
@@ -596,7 +596,7 @@ def create_inventories
       model: '13R',
       model_code: 'CPH2645',
       part_name: 'Display',
-      serial: "OP#{rand(1000000)}",
+      serial: "OP#{(10**14) + rand(10**15 - 10**14)}",
       location: "C4"
     )
   end
@@ -607,7 +607,7 @@ def create_inventories
       model: '13R',
       model_code: 'CPH2645',
       part_name: 'Mainboard',
-      imei: rand(1000000),
+      imei: (10**14) + rand(10**15 - 10**14),
       location: "C2"
     )
   end
@@ -618,7 +618,7 @@ def create_inventories
       model: '13R',
       model_code: 'CPH2645',
       part_name: 'Subboard',
-      serial: "OP#{rand(1000000)}",
+      serial: "OP#{(10**14) + rand(10**15 - 10**14)}",
       location: "C2"
     )
   end
@@ -629,7 +629,7 @@ def create_inventories
       model: 'Galaxy S23 FE',
       model_code: 'SM-S711B/DS',
       part_name: 'Mainboard',
-      imei: rand(1000000),
+      imei: (10**14) + rand(10**15 - 10**14),
       location: "B6"
     )
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -549,7 +549,9 @@ def create_inventories
   5.times do
     inventory = Inventory.create!(
       brand: 'Samsung',
+      model: 'Galaxy S23 FE',
       model_code: 'SM-S711B/DS',
+      part_name: 'Display',
       description: 'Display - Samsung Galaxy S23 FE',
       serial: "SM#{rand(1000000)}",
       location: "B7"
@@ -559,7 +561,9 @@ def create_inventories
   5.times do
     inventory = Inventory.create!(
       brand: 'Apple',
+      model: 'iPhone 15 Pro',
       model_code: 'A2848',
+      part_name: 'Battery',
       description: 'Battery - Apple iPhone 15 Pro',
       serial: "AP#{rand(1000000)}",
       location: "A1"
@@ -569,7 +573,9 @@ def create_inventories
   5.times do
     inventory = Inventory.create!(
       brand: 'OnePlus',
+      model: '13R',
       model_code: 'CPH2645',
+      part_name: 'Speaker',
       description: 'Speaker - OnePlus 13R',
       serial: "OP#{rand(1000000)}",
       location: "C3"
@@ -579,7 +585,9 @@ def create_inventories
   5.times do
     inventory = Inventory.create!(
       brand: 'Xiaomi',
+      model: '14T Pro',
       model_code: '2407FPN8EG',
+      part_name: 'Mainboard',
       description: 'Mainboard - Xiaomi 14T Pro',
       imei: rand(1000000),
       location: "E2"
@@ -589,7 +597,9 @@ def create_inventories
   5.times do
     inventory = Inventory.create!(
       brand: 'OnePlus',
+      model: '13R',
       model_code: 'CPH2645',
+      part_name: 'Display',
       description: 'Display - OnePlus 13R',
       serial: "OP#{rand(1000000)}",
       location: "C4"
@@ -599,7 +609,9 @@ def create_inventories
   5.times do
     inventory = Inventory.create!(
       brand: 'OnePlus',
+      model: '13R',
       model_code: 'CPH2645',
+      part_name: 'Mainboard',
       description: 'Mainboard - OnePlus 13R',
       imei: rand(1000000),
       location: "C2"
@@ -609,9 +621,11 @@ def create_inventories
   5.times do
     inventory = Inventory.create!(
       brand: 'OnePlus',
+      model: '13R',
       model_code: 'CPH2645',
-      description: 'Mainboard - OnePlus 13R',
-      imei: rand(1000000),
+      part_name: 'Subboard',
+      description: 'Subboard - OnePlus 13R',
+      serial: "OP#{rand(1000000)}",
       location: "C2"
     )
   end
@@ -619,7 +633,9 @@ def create_inventories
   5.times do
     inventory = Inventory.create!(
       brand: 'Samsung',
+      model: 'Galaxy S23 FE',
       model_code: 'SM-S711B/DS',
+      part_name: 'Mainboard',
       description: 'Mainboard - Samsung Galaxy S23 FE',
       imei: rand(1000000),
       location: "B6"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -552,7 +552,6 @@ def create_inventories
       model: 'Galaxy S23 FE',
       model_code: 'SM-S711B/DS',
       part_name: 'Display',
-      description: 'Display - Samsung Galaxy S23 FE',
       serial: "SM#{rand(1000000)}",
       location: "B7"
     )
@@ -564,7 +563,6 @@ def create_inventories
       model: 'iPhone 15 Pro',
       model_code: 'A2848',
       part_name: 'Battery',
-      description: 'Battery - Apple iPhone 15 Pro',
       serial: "AP#{rand(1000000)}",
       location: "A1"
     )
@@ -576,7 +574,6 @@ def create_inventories
       model: '13R',
       model_code: 'CPH2645',
       part_name: 'Speaker',
-      description: 'Speaker - OnePlus 13R',
       serial: "OP#{rand(1000000)}",
       location: "C3"
     )
@@ -588,7 +585,6 @@ def create_inventories
       model: '14T Pro',
       model_code: '2407FPN8EG',
       part_name: 'Mainboard',
-      description: 'Mainboard - Xiaomi 14T Pro',
       imei: rand(1000000),
       location: "E2"
     )
@@ -600,7 +596,6 @@ def create_inventories
       model: '13R',
       model_code: 'CPH2645',
       part_name: 'Display',
-      description: 'Display - OnePlus 13R',
       serial: "OP#{rand(1000000)}",
       location: "C4"
     )
@@ -612,7 +607,6 @@ def create_inventories
       model: '13R',
       model_code: 'CPH2645',
       part_name: 'Mainboard',
-      description: 'Mainboard - OnePlus 13R',
       imei: rand(1000000),
       location: "C2"
     )
@@ -624,7 +618,6 @@ def create_inventories
       model: '13R',
       model_code: 'CPH2645',
       part_name: 'Subboard',
-      description: 'Subboard - OnePlus 13R',
       serial: "OP#{rand(1000000)}",
       location: "C2"
     )
@@ -636,7 +629,6 @@ def create_inventories
       model: 'Galaxy S23 FE',
       model_code: 'SM-S711B/DS',
       part_name: 'Mainboard',
-      description: 'Mainboard - Samsung Galaxy S23 FE',
       imei: rand(1000000),
       location: "B6"
     )

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -301,6 +301,7 @@ def create_repairs
     imei: 4545616199875432,
     serial: 'R5KNFES127ZE9H',
     model: 'S23 FE',
+    model_code: 'SM-S711B/DS',
     device_type: 'phone'
   )
   repair.add_status(Status.find_by(name: "Received").id, User.last) # Using User.last as the acting user
@@ -315,6 +316,7 @@ def create_repairs
     imei: 138768580228309,
     serial: 'SA8028SA3463',
     model: 'iPhone 15 Pro 128GB Black',
+    model_code: 'A2848',
     device_type: 'phone',
     created_at: 3.day.ago,
     updated_at: 3.day.ago
@@ -329,7 +331,8 @@ def create_repairs
     error_description: %(The screen is broken and the customer want it fixed.),
     imei: 405512728981185,
     serial: 'SA1234SA5678',
-    model: 'S25',
+    model: 'Galaxy S25',
+    model_code: 'SM-S931B/DS',
     device_type: 'phone'
   )
   repair.add_status(Status.find_by(name: "Received").id, User.last) # Using User.last as the acting user
@@ -343,6 +346,7 @@ def create_repairs
     imei: 180324452041849,
     serial: 'SA2345SA6789',
     model: 'iPhone 13 Pro White',
+    model_code: 'A2638',
     device_type: 'phone'
   )
   repair.add_status(Status.find_by(name: "Received").id, User.last) # Using User.last as the acting user
@@ -356,6 +360,7 @@ def create_repairs
     imei: 404691323879560,
     serial: 'SA3456SA7890',
     model: '13R',
+    model_code: 'CPH2645',
     device_type: 'phone',
     created_at: 3.day.ago,
     updated_at: 3.day.ago
@@ -371,6 +376,7 @@ def create_repairs
     imei: 404691323879560,
     serial: 'SA3456SA7890',
     model: '13R',
+    model_code: 'CPH2645',
     device_type: 'phone'
   )
   repair.add_status(Status.find_by(name: "Received").id, User.last) # Using User.last as the acting user
@@ -383,6 +389,7 @@ def create_repairs
     error_description: %(DOA. The S-pen cannot track. Sometimes you can poke with it. But is impossible to draw one line without it breaking. It was like it when I opened the sales box.),
     imei: 425230367890870,
     model: 'S25 Ultra',
+    model_code: 'SM-S938B/DS',
     device_type: 'phone',
     created_at: 31.day.ago,
     updated_at: 2.day.ago
@@ -397,7 +404,8 @@ def create_repairs
     error_description: %(My iPhone was dropped in a little bit of water which it is supposed to be able to survive. Now it cannot boot. I want it fixed on warranty!),
     imei: 630576122387474,
     serial: 'SA5678SA9012',
-    model: 'iPhone 14',
+    model: 'iPhone 14 Red',
+    model_code: 'A2783',
     device_type: 'phone',
     created_at: 2.day.ago,
     updated_at: 2.day.ago
@@ -412,7 +420,8 @@ def create_repairs
     error_description: %(My phone was returned without repair last time because I did not respond to a repair offer. This is unacceptable!!! I want a new phone as it was clearly defect from the factory. I will press charges if you return the phone again!!!!),
     imei: 630576122387474,
     serial: 'SA5678SA9012',
-    model: 'iPhone 14',
+    model: 'iPhone 14 Black',
+    model_code: 'A2882',
     device_type: 'phone',
     created_at: 15.day.ago,
     updated_at: 10.day.ago
@@ -428,6 +437,7 @@ def create_repairs
     imei: 630576122387474,
     serial: 'SA5678SA9012',
     model: 'iPhone 14',
+    model_code: 'A2882',
     device_type: 'phone'
   )
   repair.add_status(Status.find_by(name: "Received").id, User.last) # Using User.last as the acting user
@@ -440,6 +450,7 @@ def create_repairs
     error_description: %(My Dead Space Remake CD is stuck inside the PlayStation.),
     serial: 'SA6789SA0123',
     model: 'PS5 slim disc',
+    model_code: 'CFI-2016',
     device_type: 'console',
     created_at: 26.day.ago,
     updated_at: 10.day.ago
@@ -455,6 +466,7 @@ def create_repairs
     imei: 659189344230575,
     serial: 'SA7890SA1234',
     model: '14T Pro Blue',
+    model_code: '2407FPN8EG',
     device_type: 'phone'
   )
   repair.add_status(Status.find_by(name: "Received").id, User.last) # Using User.last as the acting user
@@ -492,6 +504,7 @@ def create_repairs
       error_description: %(I broke 10 phones while flexing at ladies. Hello, 911? I just spotted a fox!),
       imei: rand(1000000),
       model: 'iPhone 15 Pro Max',
+      model_code: 'A3106',
       device_type: 'phone'
     )
     repair.add_status(Status.find_by(name: "Received").id, User.last) # Using User.last as the acting user
@@ -499,13 +512,14 @@ def create_repairs
 
   10.times do
     repair = Repair.create!(
-      name: 'Johnny Bravo',
-      email: 'johnny.bravo@flexing.com',
-      phone_number: 564989616,
+      name: 'Sly Cooper',
+      email: 'sly.cooper@theif.com',
+      phone_number: 988976685,
       brand: 'Apple',
-      error_description: %(I broke 10 phones while flexing at ladies. Hello, 911? I just spotted a fox!),
+      error_description: %(I somehow ended up buying 10 phones. And none of them work. They loose connection all the time.),
       imei: rand(1000000),
-      model: 'iPhone 15 Pro Max',
+      model: 'iPhone 15 Pro',
+      model_code: 'A3102',
       device_type: 'phone'
     )
     repair.add_status(Status.find_by(name: "Received").id, User.last) # Using User.last as the acting user
@@ -534,6 +548,8 @@ def create_inventories
 
   5.times do
     inventory = Inventory.create!(
+      brand: 'Samsung',
+      model_code: 'SM-S711B/DS',
       description: 'Display - Samsung Galaxy S23 FE',
       serial: "SM#{rand(1000000)}",
       location: "B7"
@@ -542,6 +558,8 @@ def create_inventories
 
   5.times do
     inventory = Inventory.create!(
+      brand: 'Apple',
+      model_code: 'A2848',
       description: 'Battery - Apple iPhone 15 Pro',
       serial: "AP#{rand(1000000)}",
       location: "A1"
@@ -550,6 +568,8 @@ def create_inventories
 
   5.times do
     inventory = Inventory.create!(
+      brand: 'OnePlus',
+      model_code: 'CPH2645',
       description: 'Speaker - OnePlus 13R',
       serial: "OP#{rand(1000000)}",
       location: "C3"
@@ -558,7 +578,9 @@ def create_inventories
 
   5.times do
     inventory = Inventory.create!(
-      description: 'Mainboard - Xiaomi 14T Pro Blue',
+      brand: 'Xiaomi',
+      model_code: '2407FPN8EG',
+      description: 'Mainboard - Xiaomi 14T Pro',
       imei: rand(1000000),
       location: "E2"
     )
@@ -566,6 +588,8 @@ def create_inventories
 
   5.times do
     inventory = Inventory.create!(
+      brand: 'OnePlus',
+      model_code: 'CPH2645',
       description: 'Display - OnePlus 13R',
       serial: "OP#{rand(1000000)}",
       location: "C4"
@@ -574,6 +598,8 @@ def create_inventories
 
   5.times do
     inventory = Inventory.create!(
+      brand: 'OnePlus',
+      model_code: 'CPH2645',
       description: 'Mainboard - OnePlus 13R',
       imei: rand(1000000),
       location: "C2"
@@ -582,6 +608,8 @@ def create_inventories
 
   5.times do
     inventory = Inventory.create!(
+      brand: 'OnePlus',
+      model_code: 'CPH2645',
       description: 'Mainboard - OnePlus 13R',
       imei: rand(1000000),
       location: "C2"
@@ -590,6 +618,8 @@ def create_inventories
 
   5.times do
     inventory = Inventory.create!(
+      brand: 'Samsung',
+      model_code: 'SM-S711B/DS',
       description: 'Mainboard - Samsung Galaxy S23 FE',
       imei: rand(1000000),
       location: "B6"


### PR DESCRIPTION
Now you just have to select the part in general like mainboard, and the system will automatically allocate the latest in Inventory matching model_code to the repair.  Qty. of parts available will update every time modal is opened. 

![image](https://github.com/user-attachments/assets/c1261084-45ec-4372-9655-6cb9d68f04d3)
